### PR TITLE
Removal of calendar tab on the school wesbite

### DIFF
--- a/_about-us/About Us.md
+++ b/_about-us/About Us.md
@@ -2,14 +2,15 @@
 title: About Us
 permalink: /about-us/
 description: ""
+variant: markdown
 ---
 <img src="/images/logo.jpg" style="width:25%">  
 
-Our school crest takes the shape of the Begonia leaf. The begonia is a red-flowering plant with dark green leaves. It is hardy and survives in almost any kind of condition. Students are encouraged at all times to emulate the enduring qualities of the Begonia.
+Our school crest takes the shape of the Begonia leaf. The begonia is a red-flowering plant with dark green leaves. It is hardy and survives in almost any kind of condition.&nbsp;Students are encouraged at all times to emulate&nbsp;the&nbsp;enduring qualities&nbsp;of&nbsp;the&nbsp;Begonia.
 
-<img src="/images/green.jpg" style="width:5%" align=left> The colour green signifies freshness, youth, growth, life, vitality and resilience.
+<img src="/images/green.jpg" style="width:5%" align="left"> The colour green signifies freshness, youth, growth, life, vitality and resilience.
 
-<img src="/images/white.jpg" style="width:5%" align=left>
+<img src="/images/white.jpg" style="width:5%" align="left">
 The colour white is the emblem of purity, virtue and brightness.
 
   

--- a/_about-us/Calendar.md
+++ b/_about-us/Calendar.md
@@ -1,9 +1,0 @@
----
-title: Calendar
-permalink: /about-us/calendar/
-description: ""
-variant: markdown
----
-#### **School Calendar 2024**
-
-Link to **[School Calendar 2024](/files/2024ZHSSCalendar.pdf)**

--- a/_about-us/collection.yml
+++ b/_about-us/collection.yml
@@ -32,7 +32,6 @@ collections:
       - Our Stakeholders/School Advisory Committee.md
       - Our Stakeholders/Zhonghua Alumni Association.md
       - Our Stakeholders/Parent Support Group.md
-      - Calendar.md
       - Rules & Regulations/.keep
       - Rules & Regulations/Rules & Regulations.md
       - Rules & Regulations/Grooming and Attire.md

--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -15,8 +15,6 @@ links:
         url: /about-us/our-people/smc/
       - title: Our Stakeholders
         url: /about-us/our-stakeholders/sac/
-      - title: Calendar
-        url: /about-us/calendar/
       - title: Rules & Regulations
         url: /about-us/rules-and-regulations/
       - title: Getting Here


### PR DESCRIPTION
have removed the calendar tab on the sch website as parents have access to the sch calendar via the PG app.